### PR TITLE
Formatting for Standard Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,74 @@
-# time_formatting
+# Time Formatting API
+
+A FastAPI application that allows users to format time.
+
+## Features
+
+- Format time in 12-hour format with AM/PM notation (standard time)
+- Accepts time input in HH:MM format
+- RESTful API
+
+## Setup
+
+1. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the application:
+```bash
+python main.py
+```
+
+Or using the run script:
+```bash
+python run.py
+```
+
+Or using uvicorn directly (port must be specified):
+```bash
+uvicorn main:app --reload --port 8001
+```
+
+The API will be available at `http://localhost:8001`
+
+## Usage
+
+### Format Time Endpoint
+
+**POST** `/format/standard`
+
+Request body:
+```json
+{
+  "time": "14:30"
+}
+```
+
+Response:
+```json
+{
+  "original_time": "14:30",
+  "formatted_time": "2:30 PM",
+  "format": "standard"
+}
+```
+
+### Example Requests
+
+**Standard time (12-hour format):**
+```bash
+curl -X POST "http://localhost:8001/format/standard" \
+  -H "Content-Type: application/json" \
+  -d '{"time": "14:30"}'
+```
+
+## Functional Requirements
+
+✅ **Standard Time Format**: The API formats time in standard (12-hour) format with AM/PM notation.
+
+✅ **Valid Time Input**: The API accepts valid time inputs in HH:MM format (24-hour input).
+
+## Quality Attributes
+
+✅ **Usability**: Users can easily view times in their selected format through a simple REST API interface.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,110 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+from datetime import time
+import re
+
+app = FastAPI(title="Time Formatting API", version="1.0.0", docs_url=None, redoc_url=None)
+
+
+class TimeFormatRequest(BaseModel):
+    time: str = Field(..., description="Time input in HH:MM format (24-hour)")
+
+
+class TimeFormatResponse(BaseModel):
+    original_time: str
+    formatted_time: str
+    format: str = "standard"
+
+
+def parse_time(time_str: str) -> time:
+    """
+    Parse time string in HH:MM format and return a time object.
+    """
+    # Remove whitespace
+    time_str = time_str.strip()
+    
+    # Parse HH:MM format
+    pattern = r'^(\d{1,2}):(\d{2})$'
+    match = re.match(pattern, time_str)
+    
+    if not match:
+        raise ValueError(f"Invalid time format: {time_str}. Expected HH:MM format")
+    
+    hour = int(match.group(1))
+    minute = int(match.group(2))
+    
+    # Validate ranges
+    if hour < 0 or hour > 23:
+        raise ValueError(f"Hour must be between 0 and 23, got {hour}")
+    if minute < 0 or minute > 59:
+        raise ValueError(f"Minute must be between 0 and 59, got {minute}")
+    
+    return time(hour, minute)
+
+
+def format_time_standard(time_obj: time) -> str:
+    """
+    Format time in 12-hour format with AM/PM notation.
+    """
+    hour = time_obj.hour
+    minute = time_obj.minute
+    
+    # Convert to 12-hour format
+    if hour == 0:
+        hour_12 = 12
+        period = "AM"
+    elif hour < 12:
+        hour_12 = hour
+        period = "AM"
+    elif hour == 12:
+        hour_12 = 12
+        period = "PM"
+    else:
+        hour_12 = hour - 12
+        period = "PM"
+    
+    return f"{hour_12}:{minute:02d} {period}"
+
+
+@app.get("/")
+async def root():
+    return {
+        "message": "Time Formatting API",
+        "endpoints": {
+            "/format/standard": "POST - Format time in standard (12-hour) format with AM/PM"
+        }
+    }
+
+
+@app.post("/format/standard", response_model=TimeFormatResponse)
+async def format_time(request: TimeFormatRequest):
+    """
+    Format a time string in standard (12-hour) format with AM/PM notation.
+    
+    - **time**: Time in HH:MM format (24-hour input)
+    
+    Returns the formatted time string in 12-hour format with AM/PM.
+    """
+    try:
+        # Parse the input time
+        time_obj = parse_time(request.time)
+        
+        # Format in standard (12-hour) format
+        formatted = format_time_standard(time_obj)
+        
+        return TimeFormatResponse(
+            original_time=request.time,
+            formatted_time=formatted,
+            format="standard"
+        )
+    
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8001)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.104.1
+uvicorn[standard]==0.24.0
+pydantic==2.5.0
+

--- a/run.py
+++ b/run.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Run the FastAPI application with uvicorn on port 8001."""
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run("main:app", host="0.0.0.0", port=8001, reload=True)
+


### PR DESCRIPTION
This PR:

1. Sets up FastAPI
2. Sets up requirements
3. Formats for standard time
4. Documents how to format in the README

Testing instructions:

1. Start the server with `python run.py`
2. Send in a cURL request to format in standard time:
```
curl -X POST "http://localhost:8001/format/standard" \
  -H "Content-Type: application/json" \
  -d '{"time": "14:30"}'
```